### PR TITLE
Update Readme and composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,67 @@
-Clock Interface
-===============
+# [WIP] PSR Clock
 
-This repository holds all the common code related to [PSR-20 (Clock Interface)][psr-url].
+## Work in Progress!
 
-Note that this is not a Clock implementation of its own. It is merely abstractions that describe the components of a Clock.
+This repository holds the interface for [PSR-20](psr-url).
 
-The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
+Note that this is not a clock of its own. It is merely an interface that
+describes a clock. See the specification for more details.
+
+**CAVEAT:** This is currently **Work in Progress**! 
+
+**Do not (I repeat: Do NOT) rely on this interface being stable!**
+
+**Using this as long as the PSR is not officially released happens at your own risk!**
+
+## Installation
+
+```bash
+# Remember: This PSR is not yet proposed and 
+# might change at any time 
+# without prior notice
+composer require psr/clock
+```
+
+## Usage
+
+If you need a clock, you can use the interface like this:
+
+```php
+<?php
+
+/*
+ * Remember: This PSR is not yet proposed and 
+ * might change at any time 
+ * without prior notice
+ */
+use Psr\Clock\ClockInterface;
+
+class Foo
+{
+    private $clock;
+
+    public function __construct(ClockInterface $clock)
+    {
+        $this->clock = $clock;
+    }
+
+    public function doSomething()
+    {
+        /** @var DateTimeImmutable $currentDateAndTime */
+        $currentDateAndTime = $this->clock()->now();
+        // do something useful with that information
+    }
+}
+```
+
+You can then pick one of the [implementations](implementation-url) of the interface to get a clock.
+
+If you want to implement the interface, you can require this package and
+implement `Psr\Clock\ClockInterface` in your code. Please read the
+[specification text](specification-url)
+for details.
 
 [psr-url]: https://www.php-fig.org/psr/psr-20
 [package-url]: https://packagist.org/packages/psr/clock
 [implementation-url]: https://packagist.org/providers/psr/clock-implementation
+[specification-url]: https://github.com/php-fig/fig-standards/blob/master/proposed/clock.md

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "psr/clock",
-  "description": "Common interface for reading the clock",
+  "description": "[WIP] Not yet proposed Common interface for reading the clock. Might change at any time without prior notice!",
   "keywords": ["psr", "psr-20", "time", "clock", "now"],
   "homepage": "https://github.com/php-fig/clock",
   "license": "MIT",


### PR DESCRIPTION
This update adds a more descriptive text to the readme (borrowed from
psr/log) and – most important at the current state – adds caveats
throughout the README and the composer.json to make clear that this is
currently Work in Progress and might change at any time without prior
notice