### PR TITLE
Fix: Replace proposed with accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ describes a clock. See the specification for more details.
 ## Installation
 
 ```bash
-# Remember: This PSR is not yet proposed and 
+# Remember: This PSR is not yet accepted and 
 # might change at any time 
 # without prior notice
 composer require psr/clock
@@ -30,7 +30,7 @@ If you need a clock, you can use the interface like this:
 <?php
 
 /*
- * Remember: This PSR is not yet proposed and 
+ * Remember: This PSR is not yet accepted and 
  * might change at any time 
  * without prior notice
  */

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "psr/clock",
-  "description": "[WIP] Not yet proposed Common interface for reading the clock. Might change at any time without prior notice!",
+  "description": "[WIP] Not yet accepted Common interface for reading the clock. Might change at any time without prior notice!",
   "keywords": ["psr", "psr-20", "time", "clock", "now"],
   "homepage": "https://github.com/php-fig/clock",
   "license": "MIT",


### PR DESCRIPTION
This pull request

- [x] replaces **proposed** with **accepted**

💁‍♂️ Since `clock.md` resides in `proposed/`, I would assume that it has been proposed.